### PR TITLE
[WIP] add templates for filters and active reference EEG

### DIFF
--- a/templates/sub-01/ses-01/eeg/sub-01_ses-01_task-FilterExample_eeg.json
+++ b/templates/sub-01/ses-01/eeg/sub-01_ses-01_task-FilterExample_eeg.json
@@ -1,0 +1,9 @@
+{
+    "HardwareFilters": {
+        "Highpass RC filter": {
+            "Half amplitude cutoff (Hz)": 0.0159,
+            "Roll-off": "6dB/Octave"
+        }
+    },
+    "SoftwareFilters": "n/a"
+}

--- a/templates/sub-01/ses-01/eeg/sub-01_ses-01_task-ReferenceExample_eeg.json
+++ b/templates/sub-01/ses-01/eeg/sub-01_ses-01_task-ReferenceExample_eeg.json
@@ -1,0 +1,6 @@
+{
+    "Manufacturer": "Biosemi",
+    "ManufacturersModelName": "ActiveTwo",
+    "EEGReference": "CMS, placed on Cz",
+    "EEGGround": "DRL, placed on Fz"
+}


### PR DESCRIPTION
fixes #97 

For accompanying description text, I could either create a `templates/sub-01/ses-01/eeg/README.md` file, or make an entry in the WIKI.

Note that the filter example is subject to change, depending on what "required format" to define the filters we finally agree on, see: https://github.com/bids-standard/bids-validator/issues/592

However, it's good to have an example of how it could look like with the current specification in the bids-validator schema.