### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please don't be shy, **the newer you are the more valuable your feedback is** :t
 
 <a href="https://summerofcode.withgoogle.com/"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/GSoC.png/220px-GSoC.png" width="125" height="125" title="GSOC" alt="GSOC"></a>
 <a href="https://www.incf.org/"><img src="https://www.eudat.eu/sites/default/files/styles/medium/public/logo/INCF_0.png?itok=uRT54XCM" width="200" height="125" title="INCF" alt="INCF"></a>
-<a href="http://www.arnoldfoundation.org/laura-and-john-arnold-foundation-announces-3-8-million-grant-to-stanford-university-to-improve-the-quality-of-neuroscience-research/"><img src="http://www.arnoldfoundation.org/wp-content/themes/arnoldfoundation/images/logo.svg" width="200" height="125" title="LJA-foundation" alt="LJA-foundation"></a>
+<a href="https://www.arnoldventures.org/newsroom/laura-and-john-arnold-foundation-announces-3-8-million-grant-to-stanford-university-to-improve-the-quality-of-neuroscience-research"><img src="https://www.arnoldventures.org/static/img/logo-on-light.svg" width="200" height="125" title="Arnold Ventures" alt="Arnold Ventures"></a>
 <a href="http://grantome.com/grant/NIH/R24-MH114705-01"><img src="http://grantome.com/images/funders/NIH.png" width="125" height="125" title="NIH" alt="NIH"></a>
 
 ### Publications

--- a/README.md
+++ b/README.md
@@ -112,15 +112,17 @@ Please don't be shy, **the newer you are the more valuable your feedback is** :t
 
 **Please consider citing the relevant papers when publishing a project that uses BIDS** 
 
+All publications are listed in our wiki: https://github.com/bids-standard/bids-starter-kit/wiki/Publications
+
+You'll almost always want to cite the original paper:
+
 [The brain imaging data structure, a format for organizing and describing outputs of neuroimaging experiments](https://www.nature.com/articles/sdata201644)
 
 >Scientific Data volume 3, Article number: 160044 (2016)
 
 <br>
 
-[MEG-BIDS, the brain imaging data structure extended to magnetoencephalography](https://www.nature.com/articles/sdata2018110)
-
->Scientific Data volume 5, Article number: 180110 (2018)
+But there are also modality specific extension papers for [MEG](https://doi.org/10.1038/sdata.2018.110), [EEG](https://doi.org/10.31234/osf.io/63a4y) and [iEEG](https://doi.org/10.31234/osf.io/r7vc2), or the [BIDS-Apps](https://doi.org/10.1371/journal.pcbi.1005209) paper that should be referenced if you're using data of that type.
 
 [gsoc]: https://summerofcode.withgoogle.com
 [patrick-github]: https://github.com/Park-Patrick


### PR DESCRIPTION
Fixes #116 

* Fix broken link to Arnold foundation press & logo
* Add links to modality specific publications

Thank you for the suggestions @nicholst!