### PR TITLE
removing DC offset correction from templates

### DIFF
--- a/matlabCode/ieeg/createBIDS_ieeg_json.m
+++ b/matlabCode/ieeg/createBIDS_ieeg_json.m
@@ -50,9 +50,6 @@ ieeg_json.SoftwareFilters = ''; % List of temporal software filters applied or
 % ideally key:value pairs of pre-applied filters and their parameter values.
 % (n/a if none). E.g., "{'HighPass': {'HalfAmplitudeCutOffHz': 1, 'RollOff: '6dB/Octave'}}".
 
-ieeg_json.DCOffsetCorrection = ''; % A description of the method (if any) used to correct for
-% a DC offset.If the method used was subtracting the mean value for each channel, use "mean".
-
 %% Recommended fields:
 
 HardwareFilters.HighpassFilter.CutoffFrequency = []; % Contains the high pass hardware filter

--- a/templates/sub-01/ses-01/ieeg/sub-01_ses-01_task-LongExample_run-01_ieeg.json
+++ b/templates/sub-01/ses-01/ieeg/sub-01_ses-01_task-LongExample_run-01_ieeg.json
@@ -3,7 +3,6 @@
     "SamplingFrequency": "",
     "PowerLineFrequency": "",
     "SoftwareFilters": "",
-    "DCOffsetCorrection": "",
     "HardwareFilters": {
         "HighpassFilter": {
             "CutoffFrequency": []


### PR DESCRIPTION
Removing DC offset correction in alignment with main spec [#237](https://github.com/bids-standard/bids-specification/issues/237) 