### PR TITLE
Use "dataset" not "project" for intro description of "Folders and Files"

### DIFF
--- a/_sources/folders_and_files/folders.md
+++ b/_sources/folders_and_files/folders.md
@@ -16,18 +16,18 @@ The rest of this page describes how these folders are structured.
 There are four main levels of the folder hierarchy, these are:
 
 ```
-project/
+dataset/
 └── subject
     └── session
         └── datatype
 ```
 
-With the exception of the top-level `project` folder, all sub-folders have a
+With the exception of the top-level `dataset/` folder, all sub-folders have a
 specific structure to their name (described below). Here's an example of how
 this hierarchy looks:
 
 ```
-myProject/
+myDataset/
 └── sub-01
     └── ses-01
         └── anat
@@ -35,7 +35,7 @@ myProject/
 
 Here is the folder name structure of each level:
 
-## project
+## dataset
 
 Can have any name, this should be descriptive for the dataset contained in the
 folder.


### PR DESCRIPTION
Opening statement talks about BIDS dataset, not a project.

Initial motivation: Although BIDS dataset CAN (and IMHO SHOULD) be used for "project", or better "study" (following BEP035 entity term) level description, then you might compose components differently. E.g. "sourcedata/raw" would actually include raw BIDS dataset, and this particular "study" level dataset would not contain "sub-*" subfolders, thus potentially breaking analogie introduced by this tutorial.

Hence, for consistency, I think we should stay with "dataset" at this level of description for now.

related backref:
- https://github.com/bids-standard/bids-specification/pull/1741